### PR TITLE
maps were crashing when topics were removed

### DIFF
--- a/app/assets/javascripts/src/Metamaps.js
+++ b/app/assets/javascripts/src/Metamaps.js
@@ -2812,10 +2812,6 @@ Metamaps.Control = {
     hideNode: function (nodeid) {
         var node = Metamaps.Visualize.mGraph.graph.getNode(nodeid);
         var graph = Metamaps.Visualize.mGraph;
-        if (nodeid == Metamaps.Visualize.mGraph.root) { // && Metamaps.Visualize.type === "RGraph"
-            var newroot = _.find(graph.graph.nodes, function(n){ return n.id !== nodeid; });
-            graph.root = newroot ? newroot.id : null;
-        }
 
         Metamaps.Control.deselectNode(node);
 
@@ -2830,6 +2826,10 @@ Metamaps.Control = {
             duration: 500
         });
         setTimeout(function () {
+            if (nodeid == Metamaps.Visualize.mGraph.root) { // && Metamaps.Visualize.type === "RGraph"
+                var newroot = _.find(graph.graph.nodes, function(n){ return n.id !== nodeid; });
+                graph.root = newroot ? newroot.id : null;
+            }
             Metamaps.Visualize.mGraph.graph.removeNode(nodeid);
         }, 500);
         Metamaps.Filter.checkMetacodes();


### PR DESCRIPTION
 (if those topics included the 'root node'). 
this was caused by a setTimeout interfering with synchronicity of events.

the change is pushed to metamaps.herokuapp.com so you can test there. Please make any comments here, not in the asana.

To help with testing, open up developer tools, go to 'console' and run the following 
`Metamaps.Visualize.mGraph.graph.getNode(Metamaps.Visualize.mGraph.root).name`

It will display the name of the node currently set as `root`. Which you can then experiment with removing/ not removing.

closes https://app.asana.com/0/15303030668422/22902140781663