### PR TITLE
install dotenv to help managed env vars

### DIFF
--- a/.example-env
+++ b/.example-env
@@ -1,0 +1,18 @@
+RAILS_ENV=development
+
+AWS_ACCESS_KEY_ID
+AWS_SECRET_ACCESS_KEY
+BUNDLE_GEMFILE
+SMTP_DOMAIN
+SMTP_PASSWORD
+SMTP_PORT
+SMTP_SERVER
+SMTP_USERNAME
+SSO_KEY
+
+## find the ENV currently in use in the app using : 
+##   grep -rIso -P "(?<=ENV)(\.fetch\(|\[).[A-Z_]+.(\)|\])" 
+
+# for a uniq ordered list of env vars:
+##   grep -rIsoh -P "(?<=ENV)(\.fetch\(|\[).[A-Z_]+.(\)|\])" | grep -oP "[A-Z_]+" | sort -u > temp 
+

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 
 realtime/node_modules
 config/database.yml
+.env
 #public/assets
 
 # Ignore bundler config

--- a/Gemfile
+++ b/Gemfile
@@ -17,6 +17,7 @@ gem 'rails3-jquery-autocomplete'
 gem 'best_in_place' #in-place editing
 gem 'kaminari' # pagination
 gem 'uservoice-ruby'
+gem 'dotenv'
 
 gem 'paperclip'
 gem 'aws-sdk'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -59,6 +59,7 @@ GEM
       responders
       thread_safe (~> 0.1)
       warden (~> 1.2.3)
+    dotenv (2.0.0)
     erubis (2.7.0)
     execjs (2.2.1)
     ezcrypto (0.7.2)
@@ -165,6 +166,7 @@ DEPENDENCIES
   cancan
   coffee-rails (~> 3.2.1)
   devise
+  dotenv
   formtastic
   formula
   jbuilder (= 0.8.2)


### PR DESCRIPTION
[dotenv](https://github.com/bkeepers/dotenv) is a nice gem that looks for a `.env` file and exports all the variables in there. 


you can keep a list of all the env (like in the .example-env) so that new people setting up your project have an idea of what they might need to configure.

I've pre-populated yours using the command at the bottom of the file

