### PR TITLE
fix filter bug

### DIFF
--- a/app/assets/javascripts/src/Metamaps.js.erb
+++ b/app/assets/javascripts/src/Metamaps.js.erb
@@ -3300,26 +3300,34 @@ Metamaps.Filter = {
         // the first option enables us to accept
         // ['Topics', 'Synapses'] as 'collection'
         if (typeof collection === "object") {
-            Metamaps[collection[0]].each(function(model) {
-                var prop = model.get(propertyToCheck) ? model.get(propertyToCheck).toString() : false;
-                if (prop && newList.indexOf(prop) === -1) {
-                    newList.push(prop);
-                }
-            });
-            Metamaps[collection[1]].each(function(model) {
-                var prop = model.get(propertyToCheck) ? model.get(propertyToCheck).toString() : false;
-                if (prop && newList.indexOf(prop) === -1) {
-                    newList.push(prop);
-                }
-            });
-        }
-        else if (typeof collection === "string") {
-            Metamaps[collection].each(function(model) {
-                var prop = model.get(propertyToCheck) ? model.get(propertyToCheck).toString() : false;
-                if (prop && newList.indexOf(prop) === -1) {
-                    newList.push(prop);
-                }
-            });
+          Metamaps[collection[0]].each(function(model) {
+            var prop = model.get(propertyToCheck);
+            if (prop !== null) {
+              prop = prop.toString();
+              if (newList.indexOf(prop) === -1) {
+                newList.push(prop);
+              }
+            }
+          });
+          Metamaps[collection[1]].each(function(model) {
+            var prop = model.get(propertyToCheck);
+            if (prop !== null) {
+              prop = prop.toString();
+              if (newList.indexOf(prop) === -1) {
+                newList.push(prop);
+              }
+            }
+          });
+        } else if (typeof collection === "string") {
+          Metamaps[collection].each(function(model) {
+            var prop = model.get(propertyToCheck);
+            if (prop !== null) {
+              prop = prop.toString();
+              if (newList.indexOf(prop) === -1) {
+                newList.push(prop);
+              }
+            }
+          });
         }
         
         removed = _.difference(self.filters[filtersToUse], newList);


### PR DESCRIPTION
It looks like the if statements in this section of the file are the issue. Since "" evaluates to false, they don't get added to the filters list. This means if you have a few "" synapses in your map, and they're already correctly in the list, updateFilters will REMOVE them from the list when you add a new synapse.

This code fixes that problem. I believe I already fixed the forking problem elsewhere in the rails 4 code. We can test that assertion during our overall testing

@Connoropolous could you check this and merge it please?