### PR TITLE
dotenv for reals

### DIFF
--- a/.example-env
+++ b/.example-env
@@ -5,18 +5,13 @@ export DB_PASSWORD='3112'
 export DB_HOST='localhost'
 export DB_PORT='5432'
 
-export MAILER_DEFAULT_URL='localhost:3000'
-# you could also use
-# export MAILER_DEFAULT_URL='metamaps.herokuapp.com'
-
 export REALTIME_SERVER='http://localhost:5001'
-# you could also use
-# export REALTIME_SERVER='https://realtime.metamaps.cc'
-# export REALTIME_SERVER='https://my-heroku-realtime-server.herokuapp.com',
+export MAILER_DEFAULT_URL='localhost:3000'
+export DEVISE_MAILER_SENDER='team@metamaps.cc'
+export DEVISE_SECRET_KEY='f71c467e526f23d614b3b08866cad4788c502bed869c282f06e73ee6c94675b62fe1f6d52fa7ba8196b33031f0d2f3b67e27ea07693c52ecebccb01700cad614'
 
-
-# you can safely leave the rest of these blank, unless you're
-# deploying an instance, in which case you'll need to set them up
+# you can safely leave these blank, unless you're deploying an instance, in which
+# case you'll need to set them up
 
 export AWS_ACCESS_KEY_ID
 export AWS_SECRET_ACCESS_KEY

--- a/.example-env
+++ b/.example-env
@@ -4,7 +4,16 @@ export DB_USERNAME='postgres'
 export DB_PASSWORD='3112'
 export DB_HOST='localhost'
 export DB_PORT='5432'
-export REALTIME_SERVER='https://realtime.metamaps.cc'
+
+export MAILER_DEFAULT_URL='localhost:3000'
+# you could also use
+# export MAILER_DEFAULT_URL='metamaps.herokuapp.com'
+
+export REALTIME_SERVER='http://localhost:5001'
+# you could also use
+# export REALTIME_SERVER='https://realtime.metamaps.cc'
+# export REALTIME_SERVER='https://my-heroku-realtime-server.herokuapp.com',
+
 
 # you can safely leave the rest of these blank, unless you're
 # deploying an instance, in which case you'll need to set them up

--- a/.example-env
+++ b/.example-env
@@ -1,14 +1,39 @@
-RAILS_ENV=development
+export RAILS_ENV='development'
 
-AWS_ACCESS_KEY_ID
-AWS_SECRET_ACCESS_KEY
-BUNDLE_GEMFILE
-SMTP_DOMAIN
-SMTP_PASSWORD
-SMTP_PORT
-SMTP_SERVER
-SMTP_USERNAME
-SSO_KEY
+export DB_USERNAME='postgres'
+export DB_PASSWORD='3112'
+export DB_HOST='localhost'
+export DB_PORT='5432'
+export REALTIME_SERVER='https://realtime.metamaps.cc'
+
+# you can safely leave the rest of these blank, unless you're
+# deploying an instance, in which case you'll need to set them up
+
+export AWS_ACCESS_KEY_ID
+export AWS_SECRET_ACCESS_KEY
+export SSO_KEY
+
+export SMTP_DOMAIN
+export SMTP_PASSWORD
+export SMTP_PORT
+export SMTP_SERVER
+export SMTP_USERNAME
+
+#ruby garbage collection stuff
+
+export RUBY_GC_TUNE=0 #set to 1 to enable GC test
+export RUBY_GC_TOKEN=4f4380fc9a2857d1f008005a3eb86928
+export RUBY_GC_HEAP_INIT_SLOTS=186426
+export RUBY_GC_HEAP_FREE_SLOTS=559278
+export RUBY_GC_HEAP_GROWTH_FACTOR=1.03
+export RUBY_GC_HEAP_GROWTH_MAX_SLOTS=74570
+export RUBY_GC_HEAP_OLDOBJECT_LIMIT_FACTOR=1.4
+export RUBY_GC_MALLOC_LIMIT=32883406
+export RUBY_GC_MALLOC_LIMIT_MAX=69055153
+export RUBY_GC_MALLOC_LIMIT_GROWTH_FACTOR=1.68
+export RUBY_GC_OLDMALLOC_LIMIT=32509481
+export RUBY_GC_OLDMALLOC_LIMIT_MAX=68269910
+export RUBY_GC_OLDMALLOC_LIMIT_GROWTH_FACTOR=1.4
 
 ## find the ENV currently in use in the app using : 
 ##   grep -rIso -P "(?<=ENV)(\.fetch\(|\[).[A-Z_]+.(\)|\])" 
@@ -16,16 +41,3 @@ SSO_KEY
 # for a uniq ordered list of env vars:
 ##   grep -rIsoh -P "(?<=ENV)(\.fetch\(|\[).[A-Z_]+.(\)|\])" | grep -oP "[A-Z_]+" | sort -u > temp 
 
-RUBY_GC_TUNE=0 #set to 1 to enable GC test
-RUBY_GC_TOKEN=4f4380fc9a2857d1f008005a3eb86928
-RUBY_GC_HEAP_INIT_SLOTS=186426
-RUBY_GC_HEAP_FREE_SLOTS=559278
-RUBY_GC_HEAP_GROWTH_FACTOR=1.03
-RUBY_GC_HEAP_GROWTH_MAX_SLOTS=74570
-RUBY_GC_HEAP_OLDOBJECT_LIMIT_FACTOR=1.4
-RUBY_GC_MALLOC_LIMIT=32883406
-RUBY_GC_MALLOC_LIMIT_MAX=69055153
-RUBY_GC_MALLOC_LIMIT_GROWTH_FACTOR=1.68
-RUBY_GC_OLDMALLOC_LIMIT=32509481
-RUBY_GC_OLDMALLOC_LIMIT_MAX=68269910
-RUBY_GC_OLDMALLOC_LIMIT_GROWTH_FACTOR=1.4

--- a/.gitignore
+++ b/.gitignore
@@ -8,16 +8,11 @@
 realtime/node_modules
 public/assets
 
-#secrets
-config/database.yml
-config/secrets.yml
+#secrets and config
 .env
 
 # Ignore bundler config
 .bundle
-
-# Ignore the default SQLite database.
-db/*.sqlite3
 
 # Ignore all logfiles and tempfiles.
 log/*.log

--- a/app/assets/javascripts/src/Metamaps.js.erb
+++ b/app/assets/javascripts/src/Metamaps.js.erb
@@ -1910,9 +1910,6 @@ Metamaps.Util = {
  *
  */
 Metamaps.Realtime = {
-    stringForLocalhost: '//localhost:5001',
-    stringForMetamaps: 'https://realtime.metamaps.cc',
-    stringForHeroku: 'https://gentle-savannah-1303.herokuapp.com',
     socket: null,
     isOpen: false,
     changing: false,
@@ -1936,9 +1933,8 @@ Metamaps.Realtime = {
         });
         $('body').click(self.close);
 
-        var railsEnv = $('body').data('env');
-        var whichToConnect = railsEnv === 'development' ? self.stringForLocalhost : self.stringForHeroku;
-        self.socket = io.connect(whichToConnect);
+        var realtimeServerUrl = '<%= ENV['REALTIME_SERVER'] %>'
+        self.socket = io.connect(realtimeServerUrl);
         self.socket.on('connect', function () {
             self.startActiveMap();
         });

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -66,7 +66,7 @@
   <![endif]-->
 </head>
 
-<body data-env="<%= Rails.env %>" class="<%= authenticated? ? "authenticated" : "unauthenticated" %>">
+<body class="<%= authenticated? ? "authenticated" : "unauthenticated" %>">
 
     <% if devise_error_messages? %>
       <p id="toast"><%= devise_error_messages! %></p>

--- a/config/database.yml
+++ b/config/database.yml
@@ -1,12 +1,12 @@
 default: &default
   min_messages: WARNING
-  adapter: postgresql
-  host: 127.0.0.1
-  port: 5432
   encoding: unicode
   pool: 5
-  username: postgres
-  password: "3112"
+  adapter: postgresql
+  host: <%= ENV['DB_HOST'] %>
+  port: <%= ENV['DB_PORT'] %>
+  username: <%= ENV['DB_USERNAME'] %>
+  password: <%= ENV['DB_PASSWORD'] %>
 
 development:
   <<: *default

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -42,7 +42,7 @@ Metamaps::Application.configure do
     authentication:       'plain',
     enable_starttls_auto: true,
     openssl_verify_mode: 'none'    }
-  config.action_mailer.default_url_options = { :host => 'metamaps.herokuapp.com' }
+  config.action_mailer.default_url_options = { :host => ENV['MAILER_DEFAULT_URL'] }
   # Don't care if the mailer can't send
   config.action_mailer.raise_delivery_errors = true
 

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -11,18 +11,13 @@ Devise.setup do |config|
   # ==> Mailer Configuration
   # Configure the e-mail address which will be shown in Devise::Mailer,
   # note that it will be overwritten if you use your own mailer class with default "from" parameter.
-  config.mailer_sender = "team@metamaps.cc"
+  config.mailer_sender = ENV['DEVISE_MAILER_SENDER']
 
   # Configure the class responsible to send e-mails.
   # config.mailer = "Devise::Mailer"
   
   
-  if Rails.env.development? # this is for Connors localhost
-    config.secret_key = 'f71c467e526f23d614b3b08866cad4788c502bed869c282f06e73ee6c94675b62fe1f6d52fa7ba8196b33031f0d2f3b67e27ea07693c52ecebccb01700cad614'
-  end
-  if Rails.env.production?  # this is for the heroku staging environment
-    config.secret_key = 'd91ba0da95749174ee2b8922034783cbde4945409ed28b13383e18e72844beb74467f8199e9e216f0687cd2290c6e46bf74da24486d14bba3671d76c5b10c753'
-  end
+  config.secret_key = ENV['DEVISE_SECRET_KEY']
     
   # ==> ORM configuration
   # Load and configure the ORM. Supports :active_record (default) and

--- a/configure.sh
+++ b/configure.sh
@@ -11,7 +11,7 @@ vagrant ssh --command "cd /vagrant; gem install bundler";
 vagrant ssh --command "cd /vagrant; bundle install";
 
 # copy the db config
-vagrant ssh --command "cd /vagrant; cp config/database.yml.default config/database.yml";
+vagrant ssh --command "cd /vagrant; cp .example-env .env";
 
 # Rake all the things
 vagrant ssh --command "cd /vagrant; rake db:create; rake db:schema:load; rake db:fixtures:load"

--- a/doc/MacInstallation.md
+++ b/doc/MacInstallation.md
@@ -1,6 +1,10 @@
+# OSX Install
+
 If you are doing an upgrade and or recent pull for changes you will need to change your default ruby package from 2.1.1 to ruby 2.1.2
 
-install homebrew
+Some of these steps are pulled from http://www.moncefbelyamani.com/how-to-install-postgresql-on-a-mac-with-homebrew-and-lunchy/
+
+Install homebrew
 
     \curl -sSL https://get.rvm.io | bash -s stable --rails
 
@@ -10,33 +14,33 @@ install homebrew
 
     gem install lunchy 
 
-(http://www.moncefbelyamani.com/how-to-install-postgresql-on-a-mac-with-homebrew-and-lunchy/)
+Now install homebrew. 
 
+    ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"
+
+Then install nodejs
+
+    brew install nodejs
+
+And postgresql:
 
     brew install postgresql
     ln -sfv /usr/local/opt/postgresql/*.plist ~/Library/LaunchAgents
     createuser metamaps -P -s -d
 
-set a password
+Set a password, then start the service:
 
     lunchy start postgres
 
-
-cd into the metamaps directory
+Change directory to the metamaps git repository, and run:
 
     bundle install
 
-
-copy the database.yml.default file and rename it database.yml
-make sure the username and password match the POSTGRES username and password you set
-
-
-http://nodejs.org/ hit install, download, open, install
-
+Copy the .example-env file and rename it to .env. Then modify the DB_USERNAME and DB_PASSWORD values to match the postgres username and password you set
 
     rake db:create
     rake db:schema:load
     rake db:fixtures:load
-    rails s 
-    
-( to start the server) 
+    rails server
+
+Now open a browser to http://localhost:3000!

--- a/doc/UbuntuInstallation.md
+++ b/doc/UbuntuInstallation.md
@@ -57,13 +57,15 @@ Install the specific version of ruby needed this will take some time
 
     rvm install ruby-2.1.3
 
-Now we also need to rename your database file which is in ./config/database.default.yml to database.yml
+Now we also need to copy .example-env to a new file named .env. Review the configuration in here to see if you need any changes.
 
-now run inside your metamaps_gen002 folder
+    cp .example-env .env
+
+Now run inside your metamaps_gen002 folder
 
     bundle install
 
-in your top lvl directory for metamaps this is a lengthy process so you might want to go and make a coffee or something :)
+in your top level directory for metamaps this is a lengthy process so you might want to go and make a coffee or something :)
 
 alright now we need to make sure your postgres password is the same as it is listed in the DB file so we are going to set it by
 

--- a/doc/WindowsInstallation.md
+++ b/doc/WindowsInstallation.md
@@ -25,7 +25,7 @@ At this point you should be in C:\git\metamaps_gen002, or whatever equivalent di
 
     start config
 
-This command will open a Windows Explorer window of the "config" directory of Metamaps. Copy database.yml.default, and rename the copy to database.yml. Edit the file and set the password to be whatever you set up with postgres earlier. Once you're done, then move back into the command prompt. The next few commands will fail unless database.yml is correctly configured and Postgres is running.
+This command will open a Windows Explorer window of the "config" directory of Metamaps. Copy `.example-env`, and rename the copy to `.env`. Edit the file and set the DB_PASSWORD to be whatever you set up with postgres earlier. Once you're done, then move back into the command prompt. The next few commands will fail unless `.env` is correctly configured and Postgres is running.
 
     rake db:create
     rake db:schema:load


### PR DESCRIPTION
centralize config in .env file

This includes removing database.yml.default and overriding that file's local changes in favour of env variables.

In future, all instance config can go in .env

Also update configure.sh and install documentation to reflect this change.

Is there anything I missed? I guess we'll find out during deploy.....