### PR TITLE
don't need xloc or yloc for Synapse mappings

### DIFF
--- a/app/models/mapping.rb
+++ b/app/models/mapping.rb
@@ -7,8 +7,10 @@ class Mapping < ActiveRecord::Base
   belongs_to :map, :class_name => "Map", :foreign_key => "map_id", touch: true
   belongs_to :user
 
-  validates :xloc, presence: true
-  validates :yloc, presence: true
+  validates :xloc, presence: true, 
+    unless: Proc.new { |m| m.mappable_type == 'Synapse' }
+  validates :yloc, presence: true,
+    unless: Proc.new { |m| m.mappable_type == 'Synapse' }
   validates :map, presence: true
   validates :mappable, presence: true
   


### PR DESCRIPTION
Fix baaaad problem on develop branch with new Synapse mapping validations, that prevented new Synapses from staying associated with the map they were on.