### PR TITLE
more token entropy

### DIFF
--- a/app/models/token.rb
+++ b/app/models/token.rb
@@ -1,11 +1,22 @@
 class Token < ActiveRecord::Base
   belongs_to :user
 
-  before_create :generate_token
+  before_create :assign_token
+
+  CHARS = 32
 
   private
+  def assign_token
+    self.token = generate_token
+  end
+
   def generate_token
-    self.token = SecureRandom.uuid.gsub(/\-/,'')
+    loop do
+      candidate = SecureRandom.base64(CHARS).gsub(/\W/, '')
+      if candidate.size >= CHARS
+        return candidate[0...CHARS]
+      end
+    end
   end
 
 end

--- a/spec/models/token_spec.rb
+++ b/spec/models/token_spec.rb
@@ -1,5 +1,10 @@
 require 'rails_helper'
 
 RSpec.describe Token, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
+  context "#generate_token" do
+    subject (:token) { Token.new }
+    it "should generate an alphanumeric token of 32 characters" do
+      expect(token.send(:generate_token)).to match /[a-zA-Z0-9]{32}/
+    end
+  end
 end

--- a/spec/models/token_spec.rb
+++ b/spec/models/token_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe Token, type: :model do
   context "#generate_token" do
     subject (:token) { Token.new }
     it "should generate an alphanumeric token of 32 characters" do
-      expect(token.send(:generate_token)).to match /[a-zA-Z0-9]{32}/
+      expect(token.send(:generate_token)).to match /^[a-zA-Z0-9]{32}$/
     end
   end
 end


### PR DESCRIPTION
Because of limited character set and some characters fixed by the UUID spec, UUID gives us way less entropy than base 64.  We like entropy :+1: 

We create a loop in case a candidate token is shorter than 32 chars.  None were when I tested a random sample of 1 million, but theoretically a token could be of length zero, which would be bad ; ) 

I split it into two methods for ease of testing.