### PR TITLE
instantiate_resource typo

### DIFF
--- a/app/controllers/api/restful_controller.rb
+++ b/app/controllers/api/restful_controller.rb
@@ -9,7 +9,7 @@ class API::RestfulController < ActionController::Base
 
   def create
     authorize resource_class
-    instantiate_resouce
+    instantiate_resource
     resource.user = current_user
     create_action
     respond_with_resource


### PR DESCRIPTION
The only problem I seem to get when testing the feature/no-cancancan branch is an error on this line....


but it happens whether I fix the typo or not.

I can see this method in snorlax, but I still get this error when POSTing to /api/v1/tokens with Postman (after logging in with my auth token)

I haven't tested using JQuery ajax.

NameError at /api/v1/tokens
 ===========================

> undefined local variable or method `instantiate_resource' for #
<Api::TokensController:0x007faaa4e292c0>

app/controllers/api/restful_controller.rb, line 12
 --------------------------------------------------

``` ruby
    7     rescue_from(Pundit::NotAuthorizedError) { |e| respond_with_standard_error e, 403 }
    8     load_and_authorize_resource only: [:show, :update, :destroy]
    9   
   10     def create
   11       authorize resource_class
>  12       instantiate_resource
   13       resource.user = current_user
   14       create_action
   15       respond_with_resource
   16     end
   17   
```