### PR TITLE
minimal import/export - could go in v2.8 for the keeners

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -25,6 +25,7 @@
 //= require ./src/views/room
 //= require ./src/JIT
 //= require ./src/Metamaps
+//= require ./src/Metamaps.Import
 //= require ./src/Metamaps.JIT
 //= require_directory ./shims
 //= require_directory ./require

--- a/app/assets/javascripts/src/Metamaps.Import.js.erb
+++ b/app/assets/javascripts/src/Metamaps.Import.js.erb
@@ -12,42 +12,34 @@
  */
 
 Metamaps.Import = {
-  headersWhitelist: [
-		'name', 'metacode', 'desc', 'link', 'permission'
+  topicWhitelist: [
+    'name', 'metacode', 'description', 'link', 'permission'
 	],
+  synapseWhitelist: [
+    'desc', 'description', 'category', 'topic1', 'topic2', 'permission'
+  ],
 
   init: function() {
     var self = Metamaps.Import;
     $('body').bind('paste', function(e) {
       var text = e.originalEvent.clipboardData.getData('text/plain');
-      var parsed = self.parseTabbedString(text);
 
-      if (parsed.length > 0 &&
-        confirm("Are you sure you want to create " + parsed.length +
-                " new topics?")) {
-        self.importTopics(parsed);
+      var results = self.parseTabbedString(text);
+      var topics = results.topics;
+      var synapses = results.synapses;
+
+      if (topics.length > 0 || synapses.length > 0) {
+        if (confirm("Are you sure you want to create " + topics.length +
+                    " new topics and " + synapses.length + " new synapses?")) {
+          self.importTopics(topics);
+          self.importSynapses(synapses);
+        }//if
       }//if
     });
   },
 
-  importTopics: function(parsedTopics) {
-    var self = Metamaps.Import;
-
-    var x = -200;
-    var y = -200;
-    parsedTopics.forEach(function(topic) {
-      self.createTopicWithParameters(
-        topic.name, topic.metacode, topic.permission,
-        topic.desc, topic.link, x, y
-      );
-
-      // update positions of topics
-      x += 50;
-      if (x > 200) {
-        y += 50;
-        x = -200;
-      }//if
-    });
+  abort: function(message) {
+    console.error(message);
   },
 
   parseTabbedString: function(text) {
@@ -58,30 +50,162 @@ Metamaps.Import = {
     if (text.indexOf("\r\n") !== -1) {
       delim = "\r\n";
     }//if
+
+    var STATES = {
+      UNKNOWN: 0,
+      TOPICS_NEED_HEADERS: 1,
+      SYNAPSES_NEED_HEADERS: 2,
+      TOPICS: 3,
+      SYNAPSES: 4,
+    };
+
+    // state & lines determine parser behaviour
+    var state = STATES.UNKNOWN;
     var lines = text.split(delim);
+    var results = { topics: [], synapses: [] }
+    var topicHeaders = [];
+    var synapseHeaders = [];
 
-    // get csv-style headers to name the object fields
-    var headers = lines[0].split('	'); //tab character
-
-    var results = [];
-    lines.forEach(function(line, index) {
-      if (index === 0) return;
-      if (line == "") return;
-
-      var topic = {};
-      line.split("	").forEach(function(field, index) {
-				if (self.headersWhitelist.indexOf(headers[index]) === -1) return;
-        topic[headers[index]] = field;
+    lines.forEach(function(line_raw, index) {
+      var line = line_raw.split('	'); // tab character
+      var noblanks = line.filter(function(elt) {
+        return elt !== "";
       });
-      results.push(topic);
+      switch(state) {
+        case STATES.UNKNOWN:
+          if (noblanks.length === 0) {
+            state = STATES.UNKNOWN;
+            break;
+          } else if (noblanks.length === 1 && line[0].toLowerCase() === 'topics') {
+            state = STATES.TOPICS_NEED_HEADERS;
+            break;
+          } else if (noblanks.length === 1 && line[0].toLowerCase() === 'synapses') {
+            state = STATES.SYNAPSES_NEED_HEADERS;
+            break;
+          }
+          state = STATES.TOPICS_NEED_HEADERS;
+          // FALL THROUGH - if we're not sure what to do, pretend
+          // we're on the TOPICS_NEED_HEADERS state and parse some headers
+
+        case STATES.TOPICS_NEED_HEADERS:
+          if (noblanks.length < 2) {
+            return self.abort("Not enough topic headers on line " + index);
+          }
+          topicHeaders = line.map(function(header, index) {
+            return header.toLowerCase().replace('description', 'desc');
+          });
+          state = STATES.TOPICS;
+          break;
+
+        case STATES.SYNAPSES_NEED_HEADERS:
+          if (noblanks.length < 2) {
+            return self.abort("Not enough synapse headers on line " + index);
+          }
+          synapseHeaders = line.map(function(header, index) {
+            return header.toLowerCase().replace('description', 'desc');
+          });
+          state = STATES.SYNAPSES;
+          break;
+
+        case STATES.TOPICS:
+          if (noblanks.length === 0) {
+            state = STATES.UNKNOWN;
+          } else if (noblanks.length === 1 && line[0].toLowerCase() === 'topics') {
+            state = STATES.TOPICS_NEED_HEADERS;
+          } else if (noblanks.length === 1 && line[0].toLowerCase() === 'synapses') {
+            state = STATES.SYNAPSES_NEED_HEADERS;
+          } else {
+            var topic = {};
+            line.forEach(function(field, index) {
+              var header = topicHeaders[index];
+              if (self.topicWhitelist.indexOf(header) === -1) return;
+              topic[header] = field;
+              if (header === 'x' || header === 'y') {
+                topic[header] = parseInt(topic[header]);
+              }//if
+            });
+            results.topics.push(topic);
+          }
+          break;
+
+        case STATES.SYNAPSES:
+          if (noblanks.length === 0) {
+            state = STATES.UNKNOWN;
+          } else if (noblanks.length === 1 && line[0].toLowerCase() === 'topics') {
+            state = STATES.TOPICS_NEED_HEADERS;
+          } else if (noblanks.length === 1 && line[0].toLowerCase() === 'synapses') {
+            state = STATES.SYNAPSES_NEED_HEADERS;
+          } else {
+            var synapse = {};
+            line.forEach(function(field, index) {
+              var header = synapseHeaders[index];
+              if (self.synapseWhitelist.indexOf(header) === -1) return;
+              synapse[header] = field;
+              if (header === 'topic1' || header === 'topic2') {
+                synapse[header] = parseInt(header);
+              }//if
+            });
+            results.synapses.push(synapse);
+          }
+          break;
+
+        default:
+          return self.abort("Invalid state while parsing import data. " +
+                            "Check code.");
+      }
     });
+
     return results;
   },
 
-  createTopicWithParameters: function(name, metacode_name, permission, desc,
-                                      link, xloc, yloc) {
-    var self = Metamaps.Topic;
 
+  importTopics: function(parsedTopics) {
+    var self = Metamaps.Import;
+
+    // up to 25 topics: scale 100
+    // up to 81 topics: scale 200
+    // up to 169 topics: scale 300
+    var scale = Math.floor((Math.sqrt(parsedTopics.length) - 1) / 4) * 100;
+    if (scale < 100) scale = 100;
+    var autoX = -scale;
+    var autoY = -scale;
+
+    parsedTopics.forEach(function(topic) {
+      var x, y;
+      if (topic.x && topic.y) {
+        x = topic.x;
+        y = topic.y;
+      } else {
+        x = autoX;
+        y = autoY;
+        autoX += 50;
+        if (autoX > scale) {
+          autoY += 50;
+          autoX = -scale;
+        }
+      }
+
+      self.createTopicWithParameters(
+        topic.name, topic.metacode, topic.permission,
+        topic.desc, topic.link, x, y, topic.id
+      );
+    });
+  },
+
+  importSynapses: function(parsedSynapses) {
+    var self = Metamaps.Import;
+
+    parsedSynapses.forEach(function(synapse) {
+      self.createSynapseWithParameters(
+        synapse.desc, synapse.category, synapse.permission,
+        synapse.topic1, synapse.topic2
+      );
+    });
+  },
+
+  createTopicWithParameters: function(name, metacode_name, permission, desc,
+                                      link, xloc, yloc, import_id) {
+    $(document).trigger(Metamaps.Map.events.editedByActiveMapper);
     var metacode = Metamaps.Metacodes.where({name: metacode_name})[0] || null;
     if (metacode === null) return console.error("metacode not found");
 
@@ -90,7 +214,8 @@ Metamaps.Import = {
       metacode_id: metacode.id,
       permission: permission || Metamaps.Active.Map.get('permission'),
       desc: desc,
-      link: link
+      link: link,
+      import_id: import_id
     });
     Metamaps.Topics.add(topic);
 
@@ -103,6 +228,32 @@ Metamaps.Import = {
     Metamaps.Mappings.add(mapping);
 
     // this function also includes the creation of the topic in the database
-    self.renderTopic(mapping, topic, true, true);
+    Metamaps.Topic.renderTopic(mapping, topic, true, true);
+
+    Metamaps.Famous.viz.hideInstructions();
+  },
+
+  createSynapseWithParameters: function(description, category, permission,
+                                        node1_id, node2_id) {
+    var topic1 = Metamaps.Topics.where({import_id: node1_id});
+    var topic2 = Metamaps.Topics.where({import_id: node2_id});
+    var node1 = topic1.get('node');
+    var node2 = topic2.get('node');
+    // TODO check if topic1 and topic2 were sucessfully found...
+
+    var synapse = new Metamaps.Backbone.Synapse({
+      desc: description,
+      category: category,
+      permission: permission,
+      node1_id: node1_id,
+      node2_id: node2_id,
+    });
+
+    var mapping = new Metamaps.Backbone.Mapping({
+      mappable_type: "Synapse",
+      mappable_id: synapse.cid,
+    });
+
+    Metamaps.Synapse.renderSynapse(mapping, synapse, node1, node2, true);
   },
 };

--- a/app/assets/javascripts/src/Metamaps.Import.js.erb
+++ b/app/assets/javascripts/src/Metamaps.Import.js.erb
@@ -24,11 +24,12 @@
 
 Metamaps.Import = {
   topicWhitelist: [
-    'name', 'metacode', 'description', 'link', 'permission'
+    'id', 'name', 'metacode', 'description', 'link', 'permission'
   ],
   synapseWhitelist: [
-    'desc', 'description', 'category', 'topic1', 'topic2', 'permission'
+    'id', 'desc', 'description', 'category', 'topic1', 'topic2', 'permission'
   ],
+  cidMappings: {}, //to be filled by import_id => cid mappings
 
   init: function() {
     var self = Metamaps.Import;
@@ -145,7 +146,7 @@ Metamaps.Import = {
               var header = topicHeaders[index];
               if (self.topicWhitelist.indexOf(header) === -1) return;
               topic[header] = field;
-              if (header === 'x' || header === 'y') {
+              if (['id', 'x', 'y'].indexOf(header) !== -1) {
                 topic[header] = parseInt(topic[header]);
               }//if
             });
@@ -166,8 +167,8 @@ Metamaps.Import = {
               var header = synapseHeaders[index];
               if (self.synapseWhitelist.indexOf(header) === -1) return;
               synapse[header] = field;
-              if (header === 'topic1' || header === 'topic2') {
-                synapse[header] = parseInt(header);
+              if (['id', 'topic1', 'topic2'].indexOf(header) !== -1) {
+                synapse[header] = parseInt(synapse[header]);
               }//if
             });
             results.synapses.push(synapse);
@@ -235,6 +236,7 @@ Metamaps.Import = {
 
   createTopicWithParameters: function(name, metacode_name, permission, desc,
                                       link, xloc, yloc, import_id) {
+    var self = Metamaps.Import;
     $(document).trigger(Metamaps.Map.events.editedByActiveMapper);
     var metacode = Metamaps.Metacodes.where({name: metacode_name})[0] || null;
     if (metacode === null) return console.error("metacode not found");
@@ -245,9 +247,9 @@ Metamaps.Import = {
       permission: permission || Metamaps.Active.Map.get('permission'),
       desc: desc,
       link: link,
-      import_id: import_id
     });
     Metamaps.Topics.add(topic);
+    self.cidMappings[import_id] = topic.cid;
 
     var mapping = new Metamaps.Backbone.Mapping({
         xloc: xloc,
@@ -260,13 +262,15 @@ Metamaps.Import = {
     // this function also includes the creation of the topic in the database
     Metamaps.Topic.renderTopic(mapping, topic, true, true);
 
+
     Metamaps.Famous.viz.hideInstructions();
   },
 
   createSynapseWithParameters: function(description, category, permission,
                                         node1_id, node2_id) {
-    var topic1 = Metamaps.Topics.where({import_id: node1_id});
-    var topic2 = Metamaps.Topics.where({import_id: node2_id});
+    var self = Metamaps.Import;
+    var topic1 = Metamaps.Topics.get(self.cidMappings[node1_id]);
+    var topic2 = Metamaps.Topics.get(self.cidMappings[node2_id]);
     var node1 = topic1.get('node');
     var node2 = topic2.get('node');
     // TODO check if topic1 and topic2 were sucessfully found...
@@ -275,13 +279,13 @@ Metamaps.Import = {
       desc: description,
       category: category,
       permission: permission,
-      node1_id: node1_id,
-      node2_id: node2_id,
+      node1_id: node1.id,
+      node2_id: node2.id,
     });
 
     var mapping = new Metamaps.Backbone.Mapping({
       mappable_type: "Synapse",
-      mappable_id: synapse.cid,
+      mappable_id: synapse.id,
     });
 
     Metamaps.Synapse.renderSynapse(mapping, synapse, node1, node2, true);

--- a/app/assets/javascripts/src/Metamaps.Import.js.erb
+++ b/app/assets/javascripts/src/Metamaps.Import.js.erb
@@ -2,19 +2,30 @@
  * Example tab-separated input:
  * Some fields will be ignored
  *
- * id	name	metacode	desc	link	user.name	permission	synapses		
- * 1	topic1	Catalyst			admin	commons	1->7		
- * 2	topic2	Event			admin	commons			
- * 5	topic	Action			admin	commons			
- * 6	topic6	Action			admin	commons	6->7		
- * 7	topic7	Action			admin	commons	7->8	 7<-6	 7<-1
- * 8	topic8	Action			admin	commons	8<-7		
+ * Topics								
+ * Id	Name	Metacode	X	Y	Description	Link	User	Permission
+ * 8	topic8	Action	-231	131			admin	commons
+ * 5	topic	Action	-229	-131			admin	commons
+ * 7	topic7.1	Action	-470	-55	hey		admin	commons
+ * 2	topic2	Event	-57	-63			admin	commons
+ * 1	topic1	Catalyst	-51	50			admin	commons
+ * 6	topic6	Action	-425	63			admin	commons
+ * 								
+ * Synapses								
+ * Id	Description	Category	Topic1	Topic2	User	Permission		
+ * 43		from-to	6	2	admin	commons		
+ * 44		from-to	6	1	admin	commons		
+ * 45		from-to	6	5	admin	commons		
+ * 46		from-to	2	7	admin	commons		
+ * 47		from-to	8	6	admin	commons		
+ * 48		from-to	8	1	admin	commons		
+ *
  */
 
 Metamaps.Import = {
   topicWhitelist: [
     'name', 'metacode', 'description', 'link', 'permission'
-	],
+  ],
   synapseWhitelist: [
     'desc', 'description', 'category', 'topic1', 'topic2', 'permission'
   ],
@@ -25,6 +36,8 @@ Metamaps.Import = {
       var text = e.originalEvent.clipboardData.getData('text/plain');
 
       var results = self.parseTabbedString(text);
+      if (results === false) return;
+
       var topics = results.topics;
       var synapses = results.synapses;
 
@@ -39,8 +52,15 @@ Metamaps.Import = {
   },
 
   abort: function(message) {
+    alert("Sorry, something went wrong!\n\n" + message);
     console.error(message);
   },
+
+	simplify: function(string) {
+		return string
+      .replace(/(^\s*|\s*$)/g, '')
+      .toLowerCase();
+	},
 
   parseTabbedString: function(text) {
     var self = Metamaps.Import;
@@ -49,9 +69,12 @@ Metamaps.Import = {
     var delim = "\n";
     if (text.indexOf("\r\n") !== -1) {
       delim = "\r\n";
+    } else if (text.indexOf("\r") !== -1) {
+      delim = "\r";
     }//if
 
     var STATES = {
+      ABORT: -1,
       UNKNOWN: 0,
       TOPICS_NEED_HEADERS: 1,
       SYNAPSES_NEED_HEADERS: 2,
@@ -67,7 +90,7 @@ Metamaps.Import = {
     var synapseHeaders = [];
 
     lines.forEach(function(line_raw, index) {
-      var line = line_raw.split('	'); // tab character
+      var line = line_raw.split("\t");
       var noblanks = line.filter(function(elt) {
         return elt !== "";
       });
@@ -76,10 +99,10 @@ Metamaps.Import = {
           if (noblanks.length === 0) {
             state = STATES.UNKNOWN;
             break;
-          } else if (noblanks.length === 1 && line[0].toLowerCase() === 'topics') {
+          } else if (noblanks.length === 1 && self.simplify(line[0]) === 'topics') {
             state = STATES.TOPICS_NEED_HEADERS;
             break;
-          } else if (noblanks.length === 1 && line[0].toLowerCase() === 'synapses') {
+          } else if (noblanks.length === 1 && self.simplify(line[0]) === 'synapses') {
             state = STATES.SYNAPSES_NEED_HEADERS;
             break;
           }
@@ -89,7 +112,8 @@ Metamaps.Import = {
 
         case STATES.TOPICS_NEED_HEADERS:
           if (noblanks.length < 2) {
-            return self.abort("Not enough topic headers on line " + index);
+            self.abort("Not enough topic headers on line " + index);
+            state = STATES.ABORT;
           }
           topicHeaders = line.map(function(header, index) {
             return header.toLowerCase().replace('description', 'desc');
@@ -99,7 +123,8 @@ Metamaps.Import = {
 
         case STATES.SYNAPSES_NEED_HEADERS:
           if (noblanks.length < 2) {
-            return self.abort("Not enough synapse headers on line " + index);
+            self.abort("Not enough synapse headers on line " + index);
+            state = STATES.ABORT;
           }
           synapseHeaders = line.map(function(header, index) {
             return header.toLowerCase().replace('description', 'desc');
@@ -148,14 +173,19 @@ Metamaps.Import = {
             results.synapses.push(synapse);
           }
           break;
-
+        case STATES.ABORT:
+          ;
         default:
-          return self.abort("Invalid state while parsing import data. " +
-                            "Check code.");
+          self.abort("Invalid state while parsing import data. Check code.");
+          state = STATES.ABORT;
       }
     });
 
-    return results;
+    if (state === STATES.ABORT) {
+      return false;
+    } else {
+      return results;
+    }
   },
 
 

--- a/app/assets/javascripts/src/Metamaps.Import.js.erb
+++ b/app/assets/javascripts/src/Metamaps.Import.js.erb
@@ -22,7 +22,9 @@ Metamaps.Import = {
       var text = e.originalEvent.clipboardData.getData('text/plain');
       var parsed = self.parseTabbedString(text);
 
-      if (confirm("Are you sure you want to create " + parsed.length + " new topics?")) {
+      if (parsed.length > 0 &&
+        confirm("Are you sure you want to create " + parsed.length +
+                " new topics?")) {
         self.importTopics(parsed);
       }//if
     });
@@ -76,7 +78,8 @@ Metamaps.Import = {
     return results;
   },
 
-  createTopicWithParameters: function(name, metacode_name, permission, desc, link, xloc, yloc) {
+  createTopicWithParameters: function(name, metacode_name, permission, desc,
+                                      link, xloc, yloc) {
     var self = Metamaps.Topic;
 
     var metacode = Metamaps.Metacodes.where({name: metacode_name})[0] || null;
@@ -99,6 +102,7 @@ Metamaps.Import = {
     });
     Metamaps.Mappings.add(mapping);
 
-    self.renderTopic(mapping, topic, true, true); // this function also includes the creation of the topic in the database
+    // this function also includes the creation of the topic in the database
+    self.renderTopic(mapping, topic, true, true);
   },
 };

--- a/app/assets/javascripts/src/Metamaps.Import.js.erb
+++ b/app/assets/javascripts/src/Metamaps.Import.js.erb
@@ -1,0 +1,104 @@
+/*
+ * Example tab-separated input:
+ * Some fields will be ignored
+ *
+ * id	name	metacode	desc	link	user.name	permission	synapses		
+ * 1	topic1	Catalyst			admin	commons	1->7		
+ * 2	topic2	Event			admin	commons			
+ * 5	topic	Action			admin	commons			
+ * 6	topic6	Action			admin	commons	6->7		
+ * 7	topic7	Action			admin	commons	7->8	 7<-6	 7<-1
+ * 8	topic8	Action			admin	commons	8<-7		
+ */
+
+Metamaps.Import = {
+  headersWhitelist: [
+		'name', 'metacode', 'desc', 'link', 'permission'
+	],
+
+  init: function() {
+    var self = Metamaps.Import;
+    $('body').bind('paste', function(e) {
+      var text = e.originalEvent.clipboardData.getData('text/plain');
+      var parsed = self.parseTabbedString(text);
+
+      if (confirm("Are you sure you want to create " + parsed.length + " new topics?")) {
+        self.importTopics(parsed);
+      }//if
+    });
+  },
+
+  importTopics: function(parsedTopics) {
+    var self = Metamaps.Import;
+
+    var x = -200;
+    var y = -200;
+    parsedTopics.forEach(function(topic) {
+      self.createTopicWithParameters(
+        topic.name, topic.metacode, topic.permission,
+        topic.desc, topic.link, x, y
+      );
+
+      // update positions of topics
+      x += 50;
+      if (x > 200) {
+        y += 50;
+        x = -200;
+      }//if
+    });
+  },
+
+  parseTabbedString: function(text) {
+    var self = Metamaps.Import;
+
+    // determine line ending and split lines
+    var delim = "\n";
+    if (text.indexOf("\r\n") !== -1) {
+      delim = "\r\n";
+    }//if
+    var lines = text.split(delim);
+
+    // get csv-style headers to name the object fields
+    var headers = lines[0].split('	'); //tab character
+
+    var results = [];
+    lines.forEach(function(line, index) {
+      if (index === 0) return;
+      if (line == "") return;
+
+      var topic = {};
+      line.split("	").forEach(function(field, index) {
+				if (self.headersWhitelist.indexOf(headers[index]) === -1) return;
+        topic[headers[index]] = field;
+      });
+      results.push(topic);
+    });
+    return results;
+  },
+
+  createTopicWithParameters: function(name, metacode_name, permission, desc, link, xloc, yloc) {
+    var self = Metamaps.Topic;
+
+    var metacode = Metamaps.Metacodes.where({name: metacode_name})[0] || null;
+    if (metacode === null) return console.error("metacode not found");
+
+    var topic = new Metamaps.Backbone.Topic({
+      name: name,
+      metacode_id: metacode.id,
+      permission: permission || Metamaps.Active.Map.get('permission'),
+      desc: desc,
+      link: link
+    });
+    Metamaps.Topics.add(topic);
+
+    var mapping = new Metamaps.Backbone.Mapping({
+        xloc: xloc,
+        yloc: yloc,
+        mappable_id: topic.cid,
+        mappable_type: "Topic",
+    });
+    Metamaps.Mappings.add(mapping);
+
+    self.renderTopic(mapping, topic, true, true); // this function also includes the creation of the topic in the database
+  },
+};

--- a/app/assets/javascripts/src/Metamaps.Import.js.erb
+++ b/app/assets/javascripts/src/Metamaps.Import.js.erb
@@ -37,7 +37,16 @@ Metamaps.Import = {
     $('body').bind('paste', function(e) {
       var text = e.originalEvent.clipboardData.getData('text/plain');
 
-      var results = self.parseTabbedString(text);
+      var results;
+      if (text[0] === '{') {
+        try {
+          results = JSON.parse(text);
+        } catch (Error e) {
+          results = false;
+        }
+      } else {
+        results = self.parseTabbedString(text);
+      }
       if (results === false) return;
 
       var topics = results.topics;

--- a/app/assets/javascripts/src/Metamaps.Import.js.erb
+++ b/app/assets/javascripts/src/Metamaps.Import.js.erb
@@ -12,22 +12,23 @@
  * 6	topic6	Action	-425	63			admin	commons
  * 								
  * Synapses								
- * Id	Description	Category	Topic1	Topic2	User	Permission		
- * 43		from-to	6	2	admin	commons		
- * 44		from-to	6	1	admin	commons		
- * 45		from-to	6	5	admin	commons		
- * 46		from-to	2	7	admin	commons		
- * 47		from-to	8	6	admin	commons		
- * 48		from-to	8	1	admin	commons		
+ * Topic1	Topic2	Category	Description	User	Permission		
+ * 6	2	from-to		admin	commons		
+ * 6	1	from-to		admin	commons		
+ * 6	5	from-to		admin	commons		
+ * 2	7	from-to		admin	commons		
+ * 8	6	from-to		admin	commons		
+ * 8	1	from-to		admin	commons		
  *
  */
 
 Metamaps.Import = {
+  // note that user is not imported
   topicWhitelist: [
-    'id', 'name', 'metacode', 'description', 'link', 'permission'
+    'id', 'name', 'metacode', 'x', 'y', 'description', 'link', 'permission'
   ],
   synapseWhitelist: [
-    'id', 'desc', 'description', 'category', 'topic1', 'topic2', 'permission'
+    'topic1', 'topic2', 'category', 'desc', 'description', 'permission'
   ],
   cidMappings: {}, //to be filled by import_id => cid mappings
 

--- a/app/assets/javascripts/src/Metamaps.js.erb
+++ b/app/assets/javascripts/src/Metamaps.js.erb
@@ -377,7 +377,7 @@ Metamaps.Backbone.init = function () {
                 mappable_id: this.isNew() ? this.cid : this.id
             });
         },
-        createEdge: function () {
+        createEdge: function (providedMapping) {
             var mapping, mappingID;
             var synapseID = this.isNew() ? this.cid : this.id;
 
@@ -391,7 +391,7 @@ Metamaps.Backbone.init = function () {
             };
 
             if (Metamaps.Active.Map) {
-                mapping = this.getMapping();
+                mapping = providedMapping || this.getMapping();
                 mappingID = mapping.isNew() ? mapping.cid : mapping.id;
                 edge.data.$mappings = [];
                 edge.data.$mappingIDs = [mappingID];
@@ -4614,7 +4614,7 @@ Metamaps.Synapse = {
 
         var edgeOnViz;
 
-        var newedge = synapse.createEdge();
+        var newedge = synapse.createEdge(mapping);
 
         Metamaps.Visualize.mGraph.graph.addAdjacence(node1, node2, newedge.data);
         edgeOnViz = Metamaps.Visualize.mGraph.graph.getAdjacence(node1.id, node2.id);

--- a/app/controllers/maps_controller.rb
+++ b/app/controllers/maps_controller.rb
@@ -85,10 +85,23 @@ class MapsController < ApplicationController
                 respond_with(@allmappers, @allmappings, @allsynapses, @alltopics, @allmessages, @map)
             }
             format.json { render json: @map }
-            format.csv { send_data @map.to_csv }
-            format.xls
+            format.csv { redirect_to :export }
+            format.xls { redirect_to :export }
         end
     end
+
+    # GET maps/:id/export
+    def export
+      map = Map.find(params[:id])
+      authorize map
+      exporter = MapExportService(current_user, map)
+      respond_to do |format|
+        format.json { render json: exporter.json }
+        format.csv { send_data exporter.csv }
+        format.xls { @spreadsheet = exporter.xls }
+      end
+    end
+
 
     # GET maps/:id/contains
     def contains

--- a/app/controllers/maps_controller.rb
+++ b/app/controllers/maps_controller.rb
@@ -85,8 +85,8 @@ class MapsController < ApplicationController
                 respond_with(@allmappers, @allmappings, @allsynapses, @alltopics, @allmessages, @map)
             }
             format.json { render json: @map }
-            format.csv { redirect_to :export }
-            format.xls { redirect_to :export }
+            format.csv { redirect_to action: :export, format: :csv }
+            format.xls { redirect_to action: :export, format: :xls }
         end
     end
 
@@ -94,7 +94,7 @@ class MapsController < ApplicationController
     def export
       map = Map.find(params[:id])
       authorize map
-      exporter = MapExportService(current_user, map)
+      exporter = MapExportService.new(current_user, map)
       respond_to do |format|
         format.json { render json: exporter.json }
         format.csv { send_data exporter.csv }

--- a/app/controllers/metacodes_controller.rb
+++ b/app/controllers/metacodes_controller.rb
@@ -1,5 +1,5 @@
 class MetacodesController < ApplicationController
-  before_action :require_admin, except: [:index]
+  before_action :require_admin, except: [:index, :show]
     
   # GET /metacodes
   # GET /metacodes.json
@@ -15,6 +15,18 @@ class MetacodesController < ApplicationController
         render :index
       }
       format.json { render json: @metacodes }
+    end
+  end
+
+  # GET /metacodes/1.json
+  # GET /metacodes/Action.json
+  # GET /metacodes/action.json
+  def show
+    @metacode = Metacode.where('DOWNCASE(name) = ?', downcase(params[:name])).first if params[:name]
+    @metacode = Metacode.find(params[:id]) unless @metacode
+
+    respond_to do |format|
+      format.json { render json: @metacode }
     end
   end
 

--- a/app/models/map.rb
+++ b/app/models/map.rb
@@ -84,50 +84,6 @@ class Map < ActiveRecord::Base
     json
   end
 
-  def to_spreadsheet
-    spreadsheet = []
-    spreadsheet << ["Topics"]
-    spreadsheet << ["Id", "Name", "Metacode", "X", "Y", "Description", "Link", "User", "Permission"]
-    self.topicmappings.each do |mapping|
-      topic = mapping.mappable
-      next if topic.nil?
-      spreadsheet << [
-        topic.id,
-        topic.name,
-        topic.metacode.name,
-        mapping.xloc,
-        mapping.yloc,
-        topic.desc,
-        topic.link,
-        topic.user.name,
-        topic.permission
-      ]
-    end
-    spreadsheet << []
-    spreadsheet << ["Synapses"]
-    spreadsheet << ["Id", "Description", "Category", "Topic1", "Topic2", "User", "Permission"]
-    self.synapses.each do |synapse|
-      spreadsheet << [
-        synapse.id,
-        synapse.desc,
-        synapse.category,
-        synapse.node1_id,
-        synapse.node2_id,
-        synapse.user.name,
-        synapse.permission
-      ]
-    end
-    spreadsheet
-  end
-
-  def to_csv(options = {})
-    CSV.generate(options) do |csv|
-      to_spreadsheet.each do |line|
-        csv << line
-      end
-    end
-  end
-
   def decode_base64(imgBase64)
     decoded_data = Base64.decode64(imgBase64)
 

--- a/app/models/map.rb
+++ b/app/models/map.rb
@@ -86,17 +86,36 @@ class Map < ActiveRecord::Base
 
   def to_csv(options = {})
     CSV.generate(options) do |csv|
-      csv << ["id", "name", "metacode", "desc", "link", "user.name", "permission", "synapses"]
-      self.topics.each do |topic|
+      csv << ["topics"]
+      csv << ["id", "name", "metacode", "x", "y", "desc", "link", "user.name", "permission"]
+      self.topicmappings.each do |mapping|
+        topic = mapping.mappable
+        next if topic.nil?
         csv << [
           topic.id,
           topic.name,
           topic.metacode.name,
+          mapping.x,
+          mapping.y,
           topic.desc,
           topic.link,
           topic.user.name,
           topic.permission,
           topic.synapses_csv("text")
+        ]
+      end
+      csv << []
+      csv << ["synapses"]
+      csv << ["id", "description", "category", "topic1", "topic2", "username", "permission"]
+      self.synapses.each do |synapse|
+        csv << [
+          synapse.id,
+          synapse.desc,
+          synapse.category,
+          synapse.node1_id,
+          synapse.node2_id,
+          synapse.user.name,
+          synapse.permission
         ]
       end
     end

--- a/app/models/map.rb
+++ b/app/models/map.rb
@@ -84,39 +84,46 @@ class Map < ActiveRecord::Base
     json
   end
 
+  def to_spreadsheet
+    spreadsheet = []
+    spreadsheet << ["Topics"]
+    spreadsheet << ["Id", "Name", "Metacode", "X", "Y", "Description", "Link", "User", "Permission"]
+    self.topicmappings.each do |mapping|
+      topic = mapping.mappable
+      next if topic.nil?
+      spreadsheet << [
+        topic.id,
+        topic.name,
+        topic.metacode.name,
+        mapping.xloc,
+        mapping.yloc,
+        topic.desc,
+        topic.link,
+        topic.user.name,
+        topic.permission
+      ]
+    end
+    spreadsheet << []
+    spreadsheet << ["Synapses"]
+    spreadsheet << ["Id", "Description", "Category", "Topic1", "Topic2", "User", "Permission"]
+    self.synapses.each do |synapse|
+      spreadsheet << [
+        synapse.id,
+        synapse.desc,
+        synapse.category,
+        synapse.node1_id,
+        synapse.node2_id,
+        synapse.user.name,
+        synapse.permission
+      ]
+    end
+    spreadsheet
+  end
+
   def to_csv(options = {})
     CSV.generate(options) do |csv|
-      csv << ["topics"]
-      csv << ["id", "name", "metacode", "x", "y", "desc", "link", "user.name", "permission"]
-      self.topicmappings.each do |mapping|
-        topic = mapping.mappable
-        next if topic.nil?
-        csv << [
-          topic.id,
-          topic.name,
-          topic.metacode.name,
-          mapping.x,
-          mapping.y,
-          topic.desc,
-          topic.link,
-          topic.user.name,
-          topic.permission,
-          topic.synapses_csv("text")
-        ]
-      end
-      csv << []
-      csv << ["synapses"]
-      csv << ["id", "description", "category", "topic1", "topic2", "username", "permission"]
-      self.synapses.each do |synapse|
-        csv << [
-          synapse.id,
-          synapse.desc,
-          synapse.category,
-          synapse.node1_id,
-          synapse.node2_id,
-          synapse.user.name,
-          synapse.permission
-        ]
+      to_spreadsheet.each do |line|
+        csv << line
       end
     end
   end

--- a/app/models/map.rb
+++ b/app/models/map.rb
@@ -101,7 +101,7 @@ class Map < ActiveRecord::Base
       end
     end
   end
-  
+
   def decode_base64(imgBase64)
     decoded_data = Base64.decode64(imgBase64)
 

--- a/app/policies/map_policy.rb
+++ b/app/policies/map_policy.rb
@@ -31,6 +31,10 @@ class MapPolicy < ApplicationPolicy
     record.permission == 'commons' || record.permission == 'public' || record.user == user
   end
 
+  def export?
+    show?
+  end
+
   def contains?
     show?
   end

--- a/app/services/map_export_service.rb
+++ b/app/services/map_export_service.rb
@@ -1,0 +1,84 @@
+class MapExportService < Struct.new(:user, :map)
+  def json
+    # marshal_dump turns OpenStruct into a Hash
+    {
+      topics: exportable_topics.map(:marshal_dump),
+      synapses: exportable_synapses.map(:marshal_dump)
+    }
+  end
+
+  def csv(options = {})
+    CSV.generate(options) do |csv|
+      to_spreadsheet.each do |line|
+        csv << line
+      end
+    end
+  end
+
+  def xls
+    to_spreadsheet
+  end
+
+  private
+
+  def topic_headings
+    [:id, :name, :metacode, :x, :y, :description, :link, :user, :permission]
+  end
+  def synapse_headings
+    [:topic1, :topic2, :category, :description, :user, :permission]
+  end
+
+  def exportable_topics
+    visible_topics ||= Pundit.policy_scope!(@user, @map.topics)
+    topic_mappings = Mapping.includes(mappable: [:metacode, :user])
+                            .where(mappable: visible_topics, map: @map)
+    topic_mappings.map do |mapping|
+      topic = mapping.mappable
+      OpenStruct.new(
+        id: topic.id,
+        name: topic.name,
+        metacode: topic.metacode.name,
+        x: mapping.xloc,
+        y: mapping.yloc,
+        description: topic.desc,
+        link: topic.link,
+        user: topic.user.name,
+        permission: topic.permission
+      )
+    end
+  end
+
+  def exportable_synapses
+    visible_synapses = Pundit.policy_scope!(@user, @map.synapses)
+    visible_synapses.map do |synapse|
+      OpenStruct.new(
+        topic1: synapse.node1_id,
+        topic2: synapse.node2_id,
+        category: synapse.category,
+        description: synapse.desc,
+        user: synapse.user.name,
+        permission: synapse.permission
+      )
+    end
+  end
+
+  def to_spreadsheet
+    spreadsheet = []
+    spreadsheet << ["Topics"]
+    spreadsheet << topic_headings.map(:capitalize)
+    exportable_topics.each do |topics|
+      # convert exportable_topics into an array of arrays
+      topic_headings.map do { |h| topics.send(h) }
+    end
+
+    spreadsheet << []
+    spreadsheet << ["Synapses"]
+    spreadsheet << synapse_headings.map(:capitalize)
+    exportable_synapses.each do |synapse|
+      # convert exportable_synapses into an array of arrays
+      synapse_headings.map do { |h| synapse.send(h) }
+    end
+
+    spreadsheet
+  end
+end

--- a/app/views/maps/export.xls.erb
+++ b/app/views/maps/export.xls.erb
@@ -1,5 +1,5 @@
 <table>
-  <% @map.to_spreadsheet.each do |line| %>
+  <% @spreadsheet.each do |line| %>
     <tr>
       <% line.each do |field| %>
         <td><%= field %></td>

--- a/app/views/maps/show.xls.erb
+++ b/app/views/maps/show.xls.erb
@@ -1,51 +1,9 @@
 <table>
-  <tr><th>Topics</th></tr>
-  <tr>
-    <th>ID</th>
-    <th>Name</th>
-    <th>Metacode</th>
-    <th>X</th>
-    <th>Y</th>
-    <th>Description</th>
-    <th>Link</th>
-    <th>Username</th>
-    <th>Permission</th>
-  </tr>
-  <% @map.topicmappings.each do |mapping| %>
-  <% topic = mapping.mappable %>
-  <% next if topic.nil? %>
-  <tr>
-    <td><%= topic.id %></td>
-    <td><%= topic.name %></td>
-    <td><%= topic.metacode.name %></td>
-    <td><%= mapping.xloc %></td>
-    <td><%= mapping.yloc %></td>
-    <td><%= topic.desc %></td>
-    <td><%= topic.link %></td>
-    <td><%= topic.user.name %></td>
-    <td><%= topic.permission %></td>
-  </tr>
-  <% end %>
-  <tr></tr>
-  <tr><th>Synapses</th></tr>
-  <tr>
-    <th>ID</th>
-    <th>Description</th>
-    <th>Category</th>
-    <th>Topic1</th>
-    <th>Topic2</th>
-    <th>Username</th>
-    <th>Permission</th>
-  </tr>
-  <% @map.synapses.each do |synapse| %>
-  <tr>
-    <td><%= synapse.id %></td>
-    <td><%= synapse.desc %></td>
-    <td><%= synapse.category %></td>
-    <td><%= synapse.node1_id %></td>
-    <td><%= synapse.node2_id %></td>
-    <td><%= synapse.user.name %></td>
-    <td><%= synapse.permission %></td>
-  </tr>
+  <% @map.to_spreadsheet.each do |line| %>
+    <tr>
+      <% line.each do |field| %>
+        <td><%= field %></td>
+      <% end %>
+    </tr>
   <% end %>
 </table>

--- a/app/views/maps/show.xls.erb
+++ b/app/views/maps/show.xls.erb
@@ -1,26 +1,51 @@
 <table>
+  <tr><th>Topics</th></tr>
   <tr>
     <th>ID</th>
     <th>Name</th>
     <th>Metacode</th>
+    <th>X</th>
+    <th>Y</th>
     <th>Description</th>
     <th>Link</th>
     <th>Username</th>
     <th>Permission</th>
-    <th>Synapses</th>
   </tr>
-  <% @map.topics.each do |topic| %>
+  <% @map.topicmappings.each do |mapping| %>
+  <% topic = mapping.mappable %>
+  <% next if topic.nil? %>
   <tr>
     <td><%= topic.id %></td>
     <td><%= topic.name %></td>
     <td><%= topic.metacode.name %></td>
+    <td><%= mapping.xloc %></td>
+    <td><%= mapping.yloc %></td>
     <td><%= topic.desc %></td>
     <td><%= topic.link %></td>
     <td><%= topic.user.name %></td>
     <td><%= topic.permission %></td>
-    <% topic.synapses_csv.each do |s_text| %>
-      <td><%= s_text %></td>
-    <% end %>
+  </tr>
+  <% end %>
+  <tr></tr>
+  <tr><th>Synapses</th></tr>
+  <tr>
+    <th>ID</th>
+    <th>Description</th>
+    <th>Category</th>
+    <th>Topic1</th>
+    <th>Topic2</th>
+    <th>Username</th>
+    <th>Permission</th>
+  </tr>
+  <% @map.synapses.each do |synapse| %>
+  <tr>
+    <td><%= synapse.id %></td>
+    <td><%= synapse.desc %></td>
+    <td><%= synapse.category %></td>
+    <td><%= synapse.node1_id %></td>
+    <td><%= synapse.node2_id %></td>
+    <td><%= synapse.user.name %></td>
+    <td><%= synapse.permission %></td>
   </tr>
   <% end %>
 </table>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -23,7 +23,10 @@ Metamaps::Application.routes.draw do
   resources :messages, only: [:show, :create, :update, :destroy]
   resources :mappings, except: [:index, :new, :edit]
   resources :metacode_sets, :except => [:show]
-  resources :metacodes, :except => [:show, :destroy]
+
+  resources :metacodes, :except => [:destroy]
+  get 'metacodes/:name', to: 'metacodes#show'
+
   resources :synapses, except: [:index, :new, :edit]
   resources :topics, except: [:index, :new, :edit] do
     get :autocomplete_topic, :on => :collection

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -36,6 +36,8 @@ Metamaps::Application.routes.draw do
   get 'topics/:id/relatives', to: 'topics#relatives', as: :relatives
   
   resources :maps, except: [:index, :new, :edit]
+  get 'maps/:id/export', to: 'maps#export'
+
   get 'explore/active', to: 'maps#activemaps'
   get 'explore/featured', to: 'maps#featuredmaps'
   get 'explore/mine', to: 'maps#mymaps'


### PR DESCRIPTION
OK, this matches the spec in #475. You can export map #999 from these urls:

    GET /maps/999.csv # redirects
    GET /maps/999.xls # redirects
    GET /maps/999/export.json
    GET /maps/999/export.csv
    GET /maps/999/export.xls

Additionally, `GET /maps/999.json` retains its old behaviour.

metacodes#show is implemented, taking a name or id as the parameter.

The export format is changed to match the spec in #475.

The import now allows tab-separated values or JSON (more formats on the way in another branch for another release), and has been changed to use the new format from #475.

This doesn't change the UI in any way, except for intercepting the results of someone copy-pasting text onto the canvas/body of a map. I don't think anyone will notice unless they're looking for it.

Future versions of this functionality will have a UI to make it simpler for users.